### PR TITLE
Location of executable updated in README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -11,4 +11,4 @@ This version is a special coding for MagicMirror²
 
 # Available commmand
 
-`.bin/MagicMirror-rebuild`
+`./node_modules/.bin/MagicMirror-rebuild`


### PR DESCRIPTION
When I ran the  installation script from the directory /hom/pi/MagicMirror the executable actually got placed in the .bin directory in ./node_modules.